### PR TITLE
delete 'pcache.o' from 'mlstor-y' list in Makefile

### DIFF
--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -28,7 +28,7 @@ CP := cp -v
 
 obj-m += mlstor.o
 
-mlstor-y := mlstor-mod.o mlstor-cache.o dmio-job.o pcache.o
+mlstor-y := mlstor-mod.o mlstor-cache.o dmio-job.o
 
 # for kernel debug
 # EXTRA_CFLAGS += -g


### PR DESCRIPTION
Synchronize the code of 'Makefile' with current state of the 'kmod' directory.